### PR TITLE
Set helpFile for the kdump spoke

### DIFF
--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -41,6 +41,7 @@ class KdumpSpoke(NormalSpoke):
     builderObjects = ["KdumpWindow", "advancedConfigBuffer"]
     mainWidgetName = "KdumpWindow"
     uiFile = "kdump.glade"
+    helpFile = "KdumpSpoke.xml"
     translationDomain = "kdump-anaconda-addon"
 
     icon = "computer-fail-symbolic"


### PR DESCRIPTION
This makes it possible to show help content for the kdump addon screen. 
Also the RHEL7 Installation Guide already has content for the kdump addon screen (KdumpSpoke.xml)
and this change is needed for it to be displayed.