### PR TITLE
Don't mix tabs and spaces for indentation

### DIFF
--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -88,7 +88,7 @@ class KdumpData(AddonData):
         if self.enabled:
             storage.bootloader.boot_args.add('crashkernel=%s' % self.reserveMB)
             ksdata.packages.packageList.append("kexec-tools")
-	    if self.enablefadump and os.path.exists(FADUMP_CAPABLE_FILE):
+        if self.enablefadump and os.path.exists(FADUMP_CAPABLE_FILE):
                 storage.bootloader.boot_args.add('fadump=on')
 
     def handle_header(self, lineno, args):


### PR DESCRIPTION
While discouraged it is still possible to mix tabs and spaces in Python
2, but in Python 3 this cases an error at runtime.

We would like to run Anaconda with Python 3 in Fedora 23 and during testing of the Python 3 Anaconda version we have hit this issue (mixing tabs and spaces).