### PR TITLE
Don't put options after the %end of the %addon section

### DIFF
--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -54,10 +54,10 @@ class KdumpData(AddonData):
         if self.reserveMB:
             addon_str += " --reserve-mb='%s'" % self.reserveMB
 
-        addon_str += "\n%s\n%%end\n" % self.content.strip()
-
         if self.enablefadump:
             addon_str += " --enablefadump"
+
+        addon_str += "\n%s\n%%end\n" % self.content.strip()
 
         return addon_str
 


### PR DESCRIPTION
Otherwise the installation describing kickstart will not be valid.
This can resulting in various issues such, as Initial Setup refusing
to run due to invalid kickstart file.