### PR TITLE
Add support for new Anaconda addon methods (#1288636)

### DIFF
--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -55,7 +55,7 @@ class KdumpData(AddonData):
 
         return addon_str
 
-    def setup(self, storage, ksdata, instClass):
+    def setup(self, storage, ksdata, instClass, payload):
         # the kdump addon should run only if requested
         if not flags.cmdline.getbool("kdump_addon", default=True):
             return
@@ -118,7 +118,7 @@ class KdumpData(AddonData):
         self.enabled = opts.enabled
         self.reserveMB =opts.reserveMB
 
-    def execute(self, storage, ksdata, instClass, users):
+    def execute(self, storage, ksdata, instClass, users, payload):
         # the KdumpSpoke should run only if requested
         if not flags.cmdline.getbool("kdump_addon", default=True):
             return


### PR DESCRIPTION
`Setup()` and `execute()` methods now have `payload` class accessible for addons.

These methods were changed in anaconda-21.48.22.67 for RHEL-7 and anaconda-25.9 for Rawhide (for the next Fedora 25).

_Related: rhbz#1288636_

Should I create another PR to master branch or is this enough?
