### PR TITLE
Fix bug #1053550 https://bugzilla.redhat.com/show_bug.cgi?id=1053550

### DIFF
--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,0 +1,114 @@
+# Serbian(Latin) translations for kexec-tools
+# Copyright (C) 2007 Red Hat, Inc.
+# This file is distributed under the same license as the kexec-tools package.
+# Miloš Komarčević <kmilos@gmail.com>, 2007.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-12 16:19+0800\n"
+"PO-Revision-Date: 2007-03-10 08:02-0500\n"
+"Last-Translator: Miloš Komarčević <kmilos@gmail.com>\n"
+"Language-Team: Serbian (sr) <fedora@prevod.org>\n"
+"Language: sr-Latn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Zanata 2.0.2\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+
+#: ../com_redhat_kdump/ks/kdump.py:120
+#, python-format
+msgid "Invalid value %s for --reserve-mb"
+msgstr ""
+
+#: ../com_redhat_kdump/tui/spokes/kdump.py:57
+msgid "Kdump"
+msgstr "Kdump"
+
+#: ../com_redhat_kdump/tui/spokes/kdump.py:85
+#: ../com_redhat_kdump/gui/spokes/kdump.py:131
+msgid "Kdump is enabled"
+msgstr ""
+
+#: ../com_redhat_kdump/tui/spokes/kdump.py:87
+#: ../com_redhat_kdump/gui/spokes/kdump.py:133
+msgid "Kdump is disabled"
+msgstr ""
+
+#: ../com_redhat_kdump/gui/spokes/kdump.py:47
+msgid "_KDUMP"
+msgstr ""
+
+#: tmp/kdump.glade.h:1
+msgid "KDUMP"
+msgstr ""
+
+#: tmp/kdump.glade.h:2
+msgid ""
+"Kdump is a kernel crash dumping mechanism. In the event of a system crash, "
+"kdump will capture information from your system that can be invaluable in "
+"determining the cause of the crash. Note that kdump does require reserving a "
+"portion of system memory that will be unavailable for other uses."
+msgstr ""
+"Kdump je mehanizam za izbačaj kraha jezgra. U slučaju kraha sistema, kdump "
+"će sakupiti podatke od sistema koji  mogu biti od neprocenjive pomoći u "
+"određivanju uzroka kraha. Primetite da kdump zahteva zauzimanje dela "
+"sistemske memorije koji neće biti dostupan za drugu upotrebu."
+
+#: tmp/kdump.glade.h:3
+msgid "Memory To Be _Reserved (MB):"
+msgstr ""
+
+#: tmp/kdump.glade.h:4
+#, fuzzy
+msgid "Total System Memory (MB):"
+msgstr "_Ukupna memorija sistema (MB):"
+
+#: tmp/kdump.glade.h:5
+#, fuzzy
+msgid "Usable System Memory (MB):"
+msgstr "_Upotrebljiva memorija sistema (MB):"
+
+#: tmp/kdump.glade.h:6
+msgid "_Enable kdump"
+msgstr ""
+
+#: tmp/kdump.glade.h:7
+msgid "_Enable dump mode fadump"
+msgstr ""
+
+#, fuzzy
+#~ msgid "Kdump Memory Reservation:"
+#~ msgstr "_Kdump memorija (MB):"
+
+#~ msgid "%s"
+#~ msgstr "%s"
+
+#~ msgid ""
+#~ "Sorry, your system does not have enough memory for kdump to be viable!"
+#~ msgstr ""
+#~ "Žalim, sistem ne poseduje dovoljno memorije kako bi kdump bio moguć!"
+
+#, fuzzy
+#~ msgid "Sorry, Xen kernels do not support kdump at this time!"
+#~ msgstr "Žalim, Xen jezgra trenutno ne podržavaju kdump!"
+
+#~ msgid "Sorry, the %s architecture does not support kdump at this time!"
+#~ msgstr "Žalim, %s arhitektura trenutno ne podržava kdump!"
+
+#, fuzzy
+#~ msgid ""
+#~ "Changing Kdump settings requires rebooting the system to reallocate "
+#~ "memory accordingly. Would you like to continue with this change and "
+#~ "reboot the system after firstboot is complete?"
+#~ msgstr ""
+#~ "Izmena Kdump podešavanja zahteva ponovno pokretanje sistema kako bi se "
+#~ "shodno zauzela memorija. %sDa li želite da nastavite sa ovom izmenom i "
+#~ "ponovo pokrenete sistem nakon što se firstboot završi?"
+
+#~ msgid "Error! No bootloader config file found, aborting configuration!"
+#~ msgstr ""
+#~ "Greška! Nije pronađena datoteka podešavanja pokretačkog programa, "
+#~ "obustavljam podešavanje!"


### PR DESCRIPTION
"Latn" is the script code according to ISO 15924 used by CLDR and libicu.
But glibc locales spell it "latin" and "Latn" doesnt' work with gettext.
So when Serbian in latin script is selected in anaconda while installing,
translations can't be displayed correctly in the kdump configuration addon.