### PR TITLE
Add support for new Anaconda addon methods (#1288636)

### DIFF
--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -61,7 +61,7 @@ class KdumpData(AddonData):
 
         return addon_str
 
-    def setup(self, storage, ksdata, instClass):
+    def setup(self, storage, ksdata, instClass, payload):
         # the kdump addon should run only if requested
         if not flags.cmdline.getbool("kdump_addon", default=False):
             return
@@ -128,7 +128,7 @@ class KdumpData(AddonData):
         self.reserveMB =opts.reserveMB
         self.enablefadump = opts.enablefadump
 
-    def execute(self, storage, ksdata, instClass, users):
+    def execute(self, storage, ksdata, instClass, users, payload):
         # the KdumpSpoke should run only if requested
         if not flags.cmdline.getbool("kdump_addon", default=False):
             return


### PR DESCRIPTION
`Setup()` and `execute()` methods now have payload class accessible for addons.

These methods were changed in `anaconda-21.48.22.67` for RHEL-7 and `anaconda-25.9` for Rawhide (for the next Fedora 25).

*Related: rhbz#1288636*