### PR TITLE
Fix 'an unknown error has occurred' issue when selecting languages using non-latin characters

### DIFF
--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -133,7 +133,7 @@ class KdumpSpoke(NormalSpoke):
         else:
             state = _("Kdump is disabled")
 
-        return state
+        return state.decode()
 
     # SIGNAL HANDLERS
     def on_enable_kdump_toggled(self, checkbutton, user_data=None):


### PR DESCRIPTION
Now when kdump_anaconda_addon is enabled and languages which use non-latin
characters are selected in anaconda, e.g. Chinese and Japanese, it will raise
an error and unable to continue to finish the installation process. This
is because 'gettext.ldgettext' will return a byte object when translation
includes non-latin character, while anaconda's core code requires a string.
Applying 'decode' method on the return value can solve this issue.

Signed-off-by: Tong Li <tonli@redhat.com>