### PR TITLE
Fix 'an unknown error has occurred' issue when selecting languages using non-latin characters

### DIFF
--- a/com_redhat_kdump/i18n.py
+++ b/com_redhat_kdump/i18n.py
@@ -23,5 +23,5 @@ __all__ = ["_", "N_"]
 
 import gettext
 
-_ = lambda x: gettext.ldgettext("kdump-anaconda-addon", x)
+_ = lambda x: gettext.translation("kdump-anaconda-addon", fallback=True).gettext(x) if x != "" else ""
 N_ = lambda x: x


### PR DESCRIPTION
Now when kdump_anaconda_addon is enabled and languages which use non-latin
characters are selected in anaconda, e.g. Chinese and Japanese, it will
raise an error and unable to continue to finish the installation process.
This is because 'gettext.ldgettext' will return a byte object when
translation includes non-latin character, while anaconda's core code
requires a string. To fix this, we apply the mothod used by pyanaconda,
which is invoking gettext after getting a translation instance. This can
make sure that a str object will be returned.