### PR TITLE
Make it possible to prevent systemctl invocation via kickstart

### DIFF
--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -137,12 +137,9 @@ class KdumpData(AddonData):
 
     def execute(self, storage, ksdata, instClass, users, payload):
         # the KdumpSpoke should run only if requested
-        if not flags.cmdline.getbool("kdump_addon", default=False):
+        if not flags.cmdline.getbool("kdump_addon", default=False) or not self.enabled:
             return
 
-        if self.enabled:
-            action = "enable"
-        else:
-            action = "disable"
+        action = "enable"
 
         util.execWithRedirect("systemctl", [action, "kdump.service"], root=util.getSysroot())


### PR DESCRIPTION
There are cases such as creation of very minimal containers where
there might be no systemctl inside the installation chroot.

In such a case we need to assure that systemctl is not called
or else the installation will fail. Unfortunately at the moment
kdump will try to always call systemctl unless the whole addon
is marked as disabled in the boot options and it's not possible
to override this behavior via kickstart.

So change the logic a bit so that when %addon com_redhat_kdump --disable
is used in kickstart will have the same effect (systemctl will not be
called).

Resolves: rhbz#1608359