### PR TITLE
Remove install classes

### DIFF
--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -53,8 +53,8 @@ class KdumpSpoke(NormalSpoke):
         # the KdumpSpoke should run only if requested
         return flags.cmdline.getbool("kdump_addon", default=False)
 
-    def __init__(self, data, storage, payload, instclass):
-        NormalSpoke.__init__(self, data, storage, payload, instclass)
+    def __init__(self, *args):
+        NormalSpoke.__init__(self, *args)
         self._reserveMem = 0
 
     def initialize(self):

--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -64,7 +64,7 @@ class KdumpData(AddonData):
 
         return addon_str
 
-    def setup(self, storage, ksdata, instClass, payload):
+    def setup(self, storage, ksdata, payload):
         # the kdump addon should run only if requested
         if not flags.cmdline.getbool("kdump_addon", default=False):
             return
@@ -135,7 +135,7 @@ class KdumpData(AddonData):
         self.reserveMB = opts.reserveMB
         self.enablefadump = opts.enablefadump
 
-    def execute(self, storage, ksdata, instClass, users, payload):
+    def execute(self, storage, ksdata, users, payload):
         # the KdumpSpoke should run only if requested
         if not flags.cmdline.getbool("kdump_addon", default=False) or not self.enabled:
             return

--- a/com_redhat_kdump/tui/spokes/kdump.py
+++ b/com_redhat_kdump/tui/spokes/kdump.py
@@ -40,8 +40,8 @@ __all__ = ["KdumpSpoke"]
 class KdumpSpoke(NormalTUISpoke):
     category = SystemCategory
 
-    def __init__(self, data, storage, payload, instclass):
-        super().__init__(data, storage, payload, instclass)
+    def __init__(self, *args):
+        super().__init__(*args)
         self.title = N_("Kdump")
         self._addon_data = self.data.addons.com_redhat_kdump
 


### PR DESCRIPTION
Anaconda removes the install classes from the code. They are
replaced with cofiguration files.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/1716