### PR TITLE
Replace getSysroot

### DIFF
--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -22,6 +22,7 @@
 import os.path
 from pyanaconda.addons import AddonData
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
@@ -143,4 +144,4 @@ class KdumpData(AddonData):
 
         action = "enable"
 
-        util.execWithRedirect("systemctl", [action, "kdump.service"], root=util.getSysroot())
+        util.execWithRedirect("systemctl", [action, "kdump.service"], root=conf.target.system_root)


### PR DESCRIPTION
Use conf.target.system_root instead of the function getSysroot to
get the path to the system root. The function getSysroot will be
removed.