### PR TITLE
Use kernel_arguments instead of cmdline

### DIFF
--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -24,7 +24,7 @@
 import os.path
 from gi.repository import Gtk
 
-from pyanaconda.flags import flags
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.utils import fancy_set_sensitive
@@ -51,7 +51,7 @@ class KdumpSpoke(NormalSpoke):
     @classmethod
     def should_run(cls, environment, data):
         # the KdumpSpoke should run only if requested
-        return flags.cmdline.getbool("kdump_addon", default=False)
+        return kernel_arguments.is_enabled("kdump_addon")
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)

--- a/com_redhat_kdump/ks/kdump.py
+++ b/com_redhat_kdump/ks/kdump.py
@@ -23,7 +23,7 @@ import os.path
 from pyanaconda.addons import AddonData
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.flags import flags
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
 
@@ -67,8 +67,9 @@ class KdumpData(AddonData):
 
     def setup(self, storage, ksdata, payload):
         # the kdump addon should run only if requested
-        if not flags.cmdline.getbool("kdump_addon", default=False):
+        if not kernel_arguments.is_enabled("kdump_addon"):
             return
+
 
         bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
 
@@ -139,7 +140,7 @@ class KdumpData(AddonData):
 
     def execute(self, storage, ksdata, users, payload):
         # the KdumpSpoke should run only if requested
-        if not flags.cmdline.getbool("kdump_addon", default=False) or not self.enabled:
+        if not kernel_arguments.is_enabled("kdump_addon") or not self.enabled:
             return
 
         action = "enable"

--- a/com_redhat_kdump/tui/spokes/kdump.py
+++ b/com_redhat_kdump/tui/spokes/kdump.py
@@ -24,7 +24,7 @@
 import os.path
 import re
 
-from pyanaconda.flags import flags
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog
@@ -54,7 +54,7 @@ class KdumpSpoke(NormalTUISpoke):
     @classmethod
     def should_run(cls, environment, data):
         # the KdumpSpoke should run only if requested
-        return flags.cmdline.getbool("kdump_addon", default=False)
+        return kernel_arguments.is_enabled("kdump_addon")
 
     def apply(self):
         pass

--- a/test/unittests/utils.py
+++ b/test/unittests/utils.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from com_redhat_kdump import common
 
 def enable_kdump_addon_in_anaconda():
-    return patch('pyanaconda.flags.cmdline.getbool', return_value=True)
+    return patch('pyanaconda.kernel.kernel_arguments.is_enabled', return_value=True)
 
 class KdumpTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Change all usages of `pyanaconda.flags.cmdline` to `pyanaconda.kernel.kernel_arguments` according to recent changes in pyanaconda 32.18 (already released).