### PR TITLE
Allow to run tests in a container

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,15 @@
+FROM fedora:rawhide
+
+RUN dnf update -y \
+  && dnf install -y \
+  make \
+  anaconda \
+  python3-pip \
+  && dnf clean all
+
+RUN pip install \
+  pylint \
+  nose
+
+RUN mkdir /kdump-anaconda-addon
+WORKDIR /kdump-anaconda-addon


### PR DESCRIPTION
Use 'make container-test' to run pylint checks and unit tests in a container.