### PR TITLE
Use the unified help support

### DIFF
--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -52,6 +52,11 @@ class KdumpSpoke(NormalSpoke):
     title = N_("_KDUMP")
     category = SystemCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "kdump-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         return is_module_available(KDUMP)

--- a/com_redhat_kdump/gui/spokes/kdump.py
+++ b/com_redhat_kdump/gui/spokes/kdump.py
@@ -45,7 +45,6 @@ class KdumpSpoke(NormalSpoke):
     builderObjects = ["KdumpWindow", "advancedConfigBuffer"]
     mainWidgetName = "KdumpWindow"
     uiFile = "kdump.glade"
-    helpFile = "KdumpSpoke.xml"
     translationDomain = "kdump-anaconda-addon"
 
     icon = "kdump"

--- a/com_redhat_kdump/tui/spokes/kdump.py
+++ b/com_redhat_kdump/tui/spokes/kdump.py
@@ -55,6 +55,11 @@ class KdumpSpoke(NormalTUISpoke):
         self._luks_devs = []
         self._ready = True
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "kdump-configuration"
+
     def _check_storage_change(self, interface, changed, invalid):
         self._ready = False
         partition = changed.get("AppliedPartitioning")


### PR DESCRIPTION
Anaconda is going to use a screen id to find the related help content.

Related: https://github.com/rhinstaller/anaconda/pull/3575