### PR TITLE
retrieve default crashkernel from kdumpctl

### DIFF
--- a/com_redhat_kdump/constants.py
+++ b/com_redhat_kdump/constants.py
@@ -25,7 +25,6 @@ from pyanaconda.modules.common.constants.namespaces import ADDONS_NAMESPACE
 
 # The constants
 FADUMP_CAPABLE_FILE = "/proc/device-tree/rtas/ibm,configure-kernel-dump"
-CRASHKERNEL_DEFAULT_FILE = "/usr/lib/modules/%s/crashkernel.default"
 
 # DBus constants
 KDUMP_NAMESPACE = (

--- a/com_redhat_kdump/gui/spokes/kdump.glade
+++ b/com_redhat_kdump/gui/spokes/kdump.glade
@@ -254,7 +254,7 @@
                       <object class="GtkLabel" id="autoReservationWarning">
                         <property name="can-focus">False</property>
                         <property name="no-show-all">True</property>
-                        <property name="label" translatable="yes">Automatic kdump memory reservation is in use. Kdump will use the default crashkernel value provided by the kernel package. This is a best-effort support and might not fit your use case. It is recommended to verify if the crashkernel value is suitable after installation.</property>
+                        <property name="label" translatable="yes">Automatic kdump memory reservation is in use. Kdump will use the default crashkernel value provided by the kexec-tools package. This is a best-effort support and might not fit your use case. It is recommended to verify if the crashkernel value is suitable after installation.</property>
                         <property name="wrap">True</property>
                       </object>
                       <packing>

--- a/com_redhat_kdump/service/kdump.py
+++ b/com_redhat_kdump/service/kdump.py
@@ -138,7 +138,6 @@ class KdumpService(KickstartService):
     def configure_bootloader_with_tasks(self, kernels):
         return [
             KdumpBootloaderConfigurationTask(
-                kernels=kernels,
                 sysroot=conf.target.system_root,
                 kdump_enabled=self.kdump_enabled,
                 fadump_enabled=self.fadump_enabled,

--- a/com_redhat_kdump/tui/spokes/kdump.py
+++ b/com_redhat_kdump/tui/spokes/kdump.py
@@ -114,7 +114,7 @@ class KdumpSpoke(NormalTUISpoke):
                 message = TextWidget(_(
                     "Automatic kdump memory reservation is in use. "
                     "Kdump will use the default crashkernel value "
-                    "provided by the kernel package. This is a "
+                    "provided by the kexec-tools package. This is a "
                     "best-effort support and might not fit "
                     "your use case. It is recommended to verify "
                     "if the crashkernel value is suitable after "

--- a/test/unit_tests/test_installation.py
+++ b/test/unit_tests/test_installation.py
@@ -15,16 +15,12 @@ CRASHKERNEL_FIXTURE = {
 
 class KdumpInstallationTestCase(TestCase):
 
-    @patch("com_redhat_kdump.common.STORAGE")
     @patch("com_redhat_kdump.service.installation.STORAGE")
-    def test_configuration_kdump_disabled(self, mock_storage, partition_storage):
+    def test_configuration_kdump_disabled(self, mock_storage):
         bootloader_proxy = mock_storage.get_proxy.return_value
         bootloader_proxy.ExtraArguments = [
             "a=1", "b=2", "c=3", "crashkernel=128M"
         ]
-
-        partition_proxy = partition_storage.get_proxy.return_value
-        partition_proxy.CreatedPartitioning = []
 
         task = KdumpBootloaderConfigurationTask(
             kernels=[],
@@ -39,16 +35,12 @@ class KdumpInstallationTestCase(TestCase):
             "a=1", "b=2", "c=3"
         ])
 
-    @patch("com_redhat_kdump.common.STORAGE")
     @patch("com_redhat_kdump.service.installation.STORAGE")
-    def test_configuration_kdump_enabled(self, mock_storage, partition_storage):
+    def test_configuration_kdump_enabled(self, mock_storage):
         bootloader_proxy = mock_storage.get_proxy.return_value
         bootloader_proxy.ExtraArguments = [
             "a=1", "b=2", "c=3", "crashkernel=128M"
         ]
-
-        partition_proxy = partition_storage.get_proxy.return_value
-        partition_proxy.CreatedPartitioning = []
 
         task = KdumpBootloaderConfigurationTask(
             kernels=[],
@@ -63,17 +55,13 @@ class KdumpInstallationTestCase(TestCase):
             "a=1", "b=2", "c=3", "crashkernel=128M"
         ])
 
-    @patch("com_redhat_kdump.common.STORAGE")
     @patch("com_redhat_kdump.service.installation.os")
     @patch("com_redhat_kdump.service.installation.STORAGE")
-    def test_configuration_fadump_enabled(self, mock_storage, mock_os, partition_storage):
+    def test_configuration_fadump_enabled(self, mock_storage, mock_os):
         bootloader_proxy = mock_storage.get_proxy.return_value
         bootloader_proxy.ExtraArguments = [
             "a=1", "b=2", "c=3", "crashkernel=256M"
         ]
-
-        partition_proxy = partition_storage.get_proxy.return_value
-        partition_proxy.CreatedPartitioning = []
 
         task = KdumpBootloaderConfigurationTask(
             kernels=[],
@@ -89,18 +77,14 @@ class KdumpInstallationTestCase(TestCase):
             "a=1", "b=2", "c=3", "fadump=on"
         ])
 
-    @patch("com_redhat_kdump.common.STORAGE")
     @patch("builtins.open", MockBuiltinRead(CRASHKERNEL_FIXTURE))
     @patch("os.path.exists", MockOsPathExists(CRASHKERNEL_FIXTURE))
     @patch("com_redhat_kdump.service.installation.STORAGE")
-    def test_configuration_kdump_crashkernel_auto(self, mock_storage, partition_storage):
+    def test_configuration_kdump_crashkernel_auto(self, mock_storage):
         bootloader_proxy = mock_storage.get_proxy.return_value
         bootloader_proxy.ExtraArguments = [
             "a=1", "b=2", "c=3", "crashkernel=auto"
         ]
-
-        partition_proxy = partition_storage.get_proxy.return_value
-        partition_proxy.CreatedPartitioning = []
 
         task = KdumpBootloaderConfigurationTask(
             kernels=['5.13'],
@@ -115,18 +99,14 @@ class KdumpInstallationTestCase(TestCase):
             "a=1", "b=2", "c=3", "crashkernel=3G"
         ])
 
-    @patch("com_redhat_kdump.common.STORAGE")
     @patch("builtins.open", MockBuiltinRead(CRASHKERNEL_FIXTURE))
     @patch("os.path.exists", MockOsPathExists(CRASHKERNEL_FIXTURE))
     @patch("com_redhat_kdump.service.installation.STORAGE")
-    def test_configuration_kdump_crashkernel_auto_fallback(self, mock_storage, partition_storage):
+    def test_configuration_kdump_crashkernel_auto_fallback(self, mock_storage):
         bootloader_proxy = mock_storage.get_proxy.return_value
         bootloader_proxy.ExtraArguments = [
             "a=1", "b=2", "c=3", "crashkernel=auto"
         ]
-
-        partition_proxy = partition_storage.get_proxy.return_value
-        partition_proxy.CreatedPartitioning = []
 
         task = KdumpBootloaderConfigurationTask(
             kernels=['non-exist'],
@@ -141,18 +121,14 @@ class KdumpInstallationTestCase(TestCase):
             "a=1", "b=2", "c=3", "crashkernel=256M"
         ])
 
-    @patch("com_redhat_kdump.common.STORAGE")
     @patch("builtins.open", MockBuiltinRead({}))
     @patch("os.path.exists", MockOsPathExists({}))
     @patch("com_redhat_kdump.service.installation.STORAGE")
-    def test_configuration_kdump_crashkernel_auto_fallback_legacy(self, mock_storage, partition_storage):
+    def test_configuration_kdump_crashkernel_auto_fallback_legacy(self, mock_storage):
         bootloader_proxy = mock_storage.get_proxy.return_value
         bootloader_proxy.ExtraArguments = [
             "a=1", "b=2", "c=3", "crashkernel=auto"
         ]
-
-        partition_proxy = partition_storage.get_proxy.return_value
-        partition_proxy.CreatedPartitioning = []
 
         task = KdumpBootloaderConfigurationTask(
             kernels=['non-exist'],


### PR DESCRIPTION
kexec-tools has removed the support for crashkernel.default and provided
"kdumpctl get-default-crashkernel [DUMP_MODE]" to retrieve default
crashkernel value.
